### PR TITLE
fix: handle rate zero

### DIFF
--- a/src/utils/position.ts
+++ b/src/utils/position.ts
@@ -124,7 +124,7 @@ export function modified(event: Modified, transaction: Transaction): Position {
       // underlyingRate = (newRate * underlyingRate) / oldRate
       position.depositedRateUnderlying = event.params.rate.times(position.depositedRateUnderlying!).div(previousPositionRate);
     } else {
-      position.depositedRateUnderlying = tokenLibrary.transformYieldBearingSharesToUnderlying(position.from, event.params.rate);
+      position.depositedRateUnderlying = tokenLibrary.transformYieldBearingSharesToUnderlying(Address.fromString(position.from), event.params.rate);
     }
   }
 

--- a/src/utils/position.ts
+++ b/src/utils/position.ts
@@ -120,9 +120,11 @@ export function modified(event: Modified, transaction: Transaction): Position {
       const newTotalUnderlying = previousTotalUnderlyingRemaining.plus(underlyingValueOfIncreasedAmount);
       // underlyingRate = (underlyingRate * remainingSwaps + toUnderlying(increaseAmount)) / newSwaps
       position.depositedRateUnderlying = newTotalUnderlying.div(position.remainingSwaps);
-    } else {
+    } else if (previousPositionRate.gt(ZERO_BI)) {
       // underlyingRate = (newRate * underlyingRate) / oldRate
       position.depositedRateUnderlying = event.params.rate.times(position.depositedRateUnderlying!).div(previousPositionRate);
+    } else {
+      position.depositedRateUnderlying = tokenLibrary.transformYieldBearingSharesToUnderlying(position.from, event.params.rate);
     }
   }
 

--- a/src/utils/position.ts
+++ b/src/utils/position.ts
@@ -124,7 +124,10 @@ export function modified(event: Modified, transaction: Transaction): Position {
       // underlyingRate = (newRate * underlyingRate) / oldRate
       position.depositedRateUnderlying = event.params.rate.times(position.depositedRateUnderlying!).div(previousPositionRate);
     } else {
-      position.depositedRateUnderlying = tokenLibrary.transformYieldBearingSharesToUnderlying(Address.fromString(position.from), event.params.rate);
+      position.depositedRateUnderlying = tokenLibrary.transformYieldBearingSharesToUnderlying(
+        Address.fromString(position.from),
+        event.params.rate
+      );
     }
   }
 


### PR DESCRIPTION
We realized that there is a corner case where the rate can be zero. When that happens, if the position is modified, then the indexing will fail because we are dividing by zero

We are now handling this case correctly, so no errors happen