### PR TITLE
feat: add more info to actions

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -342,7 +342,8 @@ type CreatedAction implements PositionActionInterface @entity {
   action: ACTION!
   "actor who executed the action"
   actor: Bytes!
-
+  "owner of the position"
+  owner: Bytes!
   "rate"
   rate: BigInt!
   "Distributed share value (optional, only if type is a yield-bearing-share)"
@@ -377,6 +378,10 @@ type TerminatedAction implements PositionActionInterface @entity {
   withdrawnRemaining: BigInt!
   "withdrawn remaining underlying (optional, when to token is yield bearing share)"
   withdrawnRemainingUnderlying: BigInt
+  "withdrawn underlying base accumulated since last withdraw (optional, when the token is yield bearing share)"
+  withdrawnUnderlyingAccum: BigInt
+  "amount of underlying funds that remainged deposited before the withdraw. Basically depositedRateUnderlying * remainingSwaps (optional, when the token is yield bearing share)"
+  depositedRemainingUnderlying: BigInt
   "transaction"
   transaction: Transaction!
   "createdAtBlock"

--- a/src/utils/position-action.ts
+++ b/src/utils/position-action.ts
@@ -32,7 +32,8 @@ export function create(
     positionAction.position = positionId;
     positionAction.action = 'CREATED';
     positionAction.actor = transaction.from;
-    (positionAction.owner = owner), (positionAction.rate = rate);
+    positionAction.owner = owner;
+    positionAction.rate = rate;
     positionAction.rateUnderlying = rateUnderlying;
     positionAction.remainingSwaps = lastSwap.minus(startingSwap).plus(ONE_BI);
     positionAction.permissions = permissions;

--- a/src/utils/position-action.ts
+++ b/src/utils/position-action.ts
@@ -1,4 +1,4 @@
-import { log, BigInt, Address } from '@graphprotocol/graph-ts';
+import { log, BigInt, Address, Bytes } from '@graphprotocol/graph-ts';
 import {
   PairSwap,
   PermissionsModifiedAction,
@@ -21,6 +21,7 @@ export function create(
   startingSwap: BigInt,
   lastSwap: BigInt,
   permissions: string[],
+  owner: Bytes,
   transaction: Transaction
 ): CreatedAction {
   const id = positionId.concat('-').concat(transaction.id);
@@ -31,8 +32,7 @@ export function create(
     positionAction.position = positionId;
     positionAction.action = 'CREATED';
     positionAction.actor = transaction.from;
-
-    positionAction.rate = rate;
+    (positionAction.owner = owner), (positionAction.rate = rate);
     positionAction.rateUnderlying = rateUnderlying;
     positionAction.remainingSwaps = lastSwap.minus(startingSwap).plus(ONE_BI);
     positionAction.permissions = permissions;
@@ -190,6 +190,8 @@ export function terminated(
   position: Position,
   withdrawnSwapped: BigInt,
   withdrawnRemaining: BigInt,
+  remainingSwaps: BigInt,
+  withdrawnUnderlyingAccum: BigInt | null,
   transaction: Transaction
 ): TerminatedAction {
   const id = position.id.concat('-').concat(transaction.id);
@@ -213,12 +215,14 @@ export function terminated(
         Address.fromString(position.to),
         withdrawnSwapped
       );
+      positionAction.withdrawnUnderlyingAccum = withdrawnUnderlyingAccum;
     }
     if (from.type == 'YIELD_BEARING_SHARE') {
       positionAction.withdrawnRemainingUnderlying = tokenLibrary.transformYieldBearingSharesToUnderlying(
         Address.fromString(position.from),
         withdrawnRemaining
       );
+      positionAction.depositedRemainingUnderlying = position.depositedRateUnderlying!.times(remainingSwaps);
     }
     positionAction.save();
   }

--- a/src/utils/position.ts
+++ b/src/utils/position.ts
@@ -66,6 +66,7 @@ export function create(event: Deposited, transaction: Transaction): Position {
       event.params.startingSwap,
       event.params.lastSwap,
       position.permissions,
+      event.params.owner,
       transaction
     );
 
@@ -193,6 +194,8 @@ export function terminated(event: Terminated, transaction: Transaction): Positio
   // Auxiliar previous position values
   const previousToWithdraw = position.toWithdraw;
   const previousRemainingLiquidity = position.remainingLiquidity;
+  const previousRemainingSwaps = position.remainingSwaps;
+  const previousToWithdrawUnderlyingAccum = position.toWithdrawUnderlyingAccum;
 
   position.rate = ZERO_BI;
   position.remainingSwaps = ZERO_BI;
@@ -212,7 +215,14 @@ export function terminated(event: Terminated, transaction: Transaction): Positio
   position.terminatedAtTimestamp = transaction.timestamp;
 
   // Position action
-  positionActionLibrary.terminated(position, previousToWithdraw, previousRemainingLiquidity, transaction);
+  positionActionLibrary.terminated(
+    position,
+    previousToWithdraw,
+    previousRemainingLiquidity,
+    previousRemainingSwaps,
+    previousToWithdrawUnderlyingAccum,
+    transaction
+  );
 
   // Save position
   position.save();


### PR DESCRIPTION
We are now adding more info into actions:
* Created
  * Owner
* Terminated
  *  `withdrawnUnderlyingAccum` & `depositedRemainingUnderlying`, to be able to calculate yield